### PR TITLE
Dependency Checks Refactor

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -66,14 +66,16 @@ func getTransport(transportType string, conflationMgr *conflator.ConflationManag
 	}
 }
 
-// returns whether initial bundle dependencies should be enforced or not based on transport type.
+// function to determine whether the transport component requires initial-dependencies between bundles to be checked
+// (on load). If the returned is false, then we may assume that dependency of the initial bundle of
+// each type is met. Otherwise, there are no guarantees and the dependencies must be checked.
 func requireInitialDependencyChecks(transportType string) bool {
 	switch transportType {
 	case kafkaTransportTypeName:
 		return false
 		// once kafka consumer loads up, it starts reading from the earliest un-processed bundle,
 		// as in all bundles that precede the latter have been processed, which include its dependency
-		// bundle (due to order guarantee).
+		// bundle.
 
 		// the order guarantee also guarantees that if while loading this component, a new bundle is written to a-
 		// partition, then surely its dependency was written before it (leaf-hub-status-sync on kafka guarantees).

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -178,9 +178,9 @@ func createManager(leaderElectionNamespace string, transportType string, workers
 	}
 	// conflationReadyQueue is shared between ConflationManager and dispatcher
 	conflationReadyQueue := conflator.NewConflationReadyQueue(statistics)
-	requireInitialDependenciesChecks := requireInitialDependencyChecks(transportType)
+	requireInitialDependencyChecks := requireInitialDependencyChecks(transportType)
 	conflationManager := conflator.NewConflationManager(ctrl.Log.WithName("conflation"), conflationReadyQueue,
-		requireInitialDependenciesChecks, statistics) // manage all Conflation Units
+		requireInitialDependencyChecks, statistics) // manage all Conflation Units
 
 	// transport layer initialization
 	transportObj, err := getTransport(transportType, conflationManager, statistics)

--- a/pkg/conflator/conflation_manager.go
+++ b/pkg/conflator/conflation_manager.go
@@ -11,27 +11,27 @@ import (
 
 // NewConflationManager creates a new instance of ConflationManager.
 func NewConflationManager(log logr.Logger, conflationUnitsReadyQueue *ConflationReadyQueue,
-	requireInitialDependenciesChecks bool, statistics *statistics.Statistics) *ConflationManager {
+	requireInitialDependencyChecks bool, statistics *statistics.Statistics) *ConflationManager {
 	return &ConflationManager{
-		log:                              log,
-		conflationUnits:                  make(map[string]*ConflationUnit), // map from leaf hub to conflation unit
-		requireInitialDependenciesChecks: requireInitialDependenciesChecks,
-		registrations:                    make([]*ConflationRegistration, 0),
-		readyQueue:                       conflationUnitsReadyQueue,
-		lock:                             sync.Mutex{}, // lock to be used to find/create conflation units
-		statistics:                       statistics,
+		log:                            log,
+		conflationUnits:                make(map[string]*ConflationUnit), // map from leaf hub to conflation unit
+		requireInitialDependencyChecks: requireInitialDependencyChecks,
+		registrations:                  make([]*ConflationRegistration, 0),
+		readyQueue:                     conflationUnitsReadyQueue,
+		lock:                           sync.Mutex{}, // lock to be used to find/create conflation units
+		statistics:                     statistics,
 	}
 }
 
 // ConflationManager implements conflation units management.
 type ConflationManager struct {
-	log                              logr.Logger
-	conflationUnits                  map[string]*ConflationUnit // map from leaf hub to conflation unit
-	requireInitialDependenciesChecks bool
-	registrations                    []*ConflationRegistration
-	readyQueue                       *ConflationReadyQueue
-	lock                             sync.Mutex
-	statistics                       *statistics.Statistics
+	log                            logr.Logger
+	conflationUnits                map[string]*ConflationUnit // map from leaf hub to conflation unit
+	requireInitialDependencyChecks bool
+	registrations                  []*ConflationRegistration
+	readyQueue                     *ConflationReadyQueue
+	lock                           sync.Mutex
+	statistics                     *statistics.Statistics
 }
 
 // Register registers bundle type with priority and handler function within the conflation manager.
@@ -65,7 +65,7 @@ func (cm *ConflationManager) getConflationUnit(leafHubName string) *ConflationUn
 	}
 	// otherwise, need to create conflation unit
 	conflationUnit := newConflationUnit(cm.log, cm.readyQueue, cm.registrations,
-		cm.requireInitialDependenciesChecks, cm.statistics)
+		cm.requireInitialDependencyChecks, cm.statistics)
 	cm.conflationUnits[leafHubName] = conflationUnit
 
 	return conflationUnit

--- a/pkg/conflator/conflation_unit.go
+++ b/pkg/conflator/conflation_unit.go
@@ -47,7 +47,7 @@ func newConflationUnit(log logr.Logger, readyQueue *ConflationReadyQueue,
 			handlerFunction:            registration.handlerFunction,
 			dependency:                 registration.dependency, // nil if there is no dependency
 			isInProcess:                false,
-			lastProcessedBundleVersion: noVersion(),
+			lastProcessedBundleVersion: noBundleVersion(),
 		}
 
 		bundleTypeToPriority[registration.bundleType] = registration.priority
@@ -245,7 +245,7 @@ func (cu *ConflationUnit) checkDependency(conflationElement *conflationElement) 
 	dependencyIndex := cu.bundleTypeToPriority[conflationElement.dependency.BundleType]
 	dependencyLastProcessedVersion := cu.priorityQueue[dependencyIndex].lastProcessedBundleVersion
 
-	if !cu.requireInitialDependencyChecks && dependencyLastProcessedVersion.Equals(noVersion()) {
+	if !cu.requireInitialDependencyChecks && dependencyLastProcessedVersion.Equals(noBundleVersion()) {
 		return true // transport does not require initial dependency check
 	}
 
@@ -261,6 +261,6 @@ func (cu *ConflationUnit) checkDependency(conflationElement *conflationElement) 
 	}
 }
 
-func noVersion() *status.BundleVersion {
+func noBundleVersion() *status.BundleVersion {
 	return status.NewBundleVersion(0, 0)
 }

--- a/pkg/conflator/conflation_unit.go
+++ b/pkg/conflator/conflation_unit.go
@@ -34,7 +34,7 @@ type ResultReporter interface {
 }
 
 func newConflationUnit(log logr.Logger, readyQueue *ConflationReadyQueue,
-	registrations []*ConflationRegistration, requireInitialDependencyCheck bool,
+	registrations []*ConflationRegistration, requireInitialDependencyChecks bool,
 	statistics *statistics.Statistics) *ConflationUnit {
 	priorityQueue := make([]*conflationElement, len(registrations))
 	bundleTypeToPriority := make(map[string]conflationPriority)
@@ -50,7 +50,7 @@ func newConflationUnit(log logr.Logger, readyQueue *ConflationReadyQueue,
 			lastProcessedBundleVersion: nil,
 		}
 
-		if requireInitialDependencyCheck {
+		if requireInitialDependencyChecks {
 			// if the initial dependencies must be enforced then we initiate the last processed bundle
 			// version to 0,0.
 			// otherwise, the version should remain nil, which the dependency checks allow and count as fine.


### PR DESCRIPTION
implemented a "free dependency pass" mechanism where if transport is  kafka then conflation units would allow a 1 time dependency check to proceed, if the base is on partition with an offset lower than that of the bundle being handled.